### PR TITLE
feat: local storage unique keys

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,8 +27,6 @@
         </div>
 
         <vue-table v-bind="options" :items.sync="items">
-
-
             <template v-slot:action-edit="slotProps">
                 <a class="btn btn-info"
                    :href="`${options.uri}/${slotProps.item.id}/edit`"

--- a/src/directives/custom/filter-column.directive.js
+++ b/src/directives/custom/filter-column.directive.js
@@ -1,6 +1,8 @@
+import { filtersStorageName } from "../../store/modules/filters.module";
+
 export const columnFilter = {
     bind: function (el, binding, vnode) {
-        let storedFilters = window.localStorage.getItem('filters');
+        let storedFilters = window.localStorage.getItem(filtersStorageName);
 
         storedFilters = storedFilters ? JSON.parse(storedFilters) : [];
 

--- a/src/store/modules/filters.module.js
+++ b/src/store/modules/filters.module.js
@@ -1,4 +1,6 @@
-let filters = window.localStorage.getItem('filters');
+export const filtersStorageName = `vue_table_${ window.location.pathname }_filters`;
+
+let filters = window.localStorage.getItem(filtersStorageName);
 
 export const filtersModule = {
     namespaced: true,
@@ -27,7 +29,7 @@ export const filtersModule = {
          * @param state
          */
         saveData(state) {
-            window.localStorage.setItem('filters', JSON.stringify(state.filters));
+            window.localStorage.setItem(filtersStorageName, JSON.stringify(state.filters));
         }
     },
     actions: {


### PR DESCRIPTION
### Description

The app now generates storage names with the following format:
`[component name]_[window location]_[store module name]`
It's a good improvement, despite the fact that there is still one component per page limitation.

### Fixes

This fixes #13.



